### PR TITLE
Improve plurals handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ New source string event:
       "url": "http://example.com/translate/test/test/cs/?checksum=6412684aaf018e8e",
       "component": "test",
       "translation": "cs",
-      "source": "Hello, world!\n"
+      "source": ["Hello, world!\n"]
     }
 
 Resource update event:
@@ -178,7 +178,7 @@ New contributor event:
       "project": "test",
       "component": "test",
       "translation": "cs",
-      "source": "Hello, world!\n"
+      "source": ["Hello, world!\n"]
     }
 
 New translation event:
@@ -190,11 +190,11 @@ New translation event:
       "action": "New translation",
       "timestamp": "2019-10-17T15:57:08.772591+00:00",
       "url": "http://example.com/translate/test/test/cs/?checksum=6412684aaf018e8e",
-      "target": "Ahoj svete!\n",
+      "target": ["Ahoj svete!\n"],
       "author": "testuser",
       "user": "testuser",
       "project": "test",
       "component": "test",
       "translation": "cs",
-      "source": "Hello, world!\n"
+      "source": ["Hello, world!\n"]
     }

--- a/weblate_fedora_messaging/tasks.py
+++ b/weblate_fedora_messaging/tasks.py
@@ -21,6 +21,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from fedora_messaging.api import Message, publish
 from fedora_messaging.exceptions import ConnectionException, PublishReturned
 from weblate.trans.models import Change
+from weblate.trans.util import split_plural
 from weblate.utils.celery import app
 from weblate.utils.site import get_site_url
 
@@ -50,9 +51,9 @@ def get_change_body(change):
     if url:
         result["url"] = get_site_url(url)
     if change.target:
-        result["target"] = change.target
+        result["target"] = split_plural(change.target)
     if change.old:
-        result["old"] = change.old
+        result["old"] = split_plural(change.old)
     if change.author:
         result["author"] = change.author.username
     if change.user:
@@ -64,7 +65,7 @@ def get_change_body(change):
     if change.translation:
         result["translation"] = change.translation.language.code
     if change.unit:
-        result["source"] = change.unit.source
+        result["source"] = split_plural(change.unit.source)
     result.update(change.details)
     return result
 

--- a/weblate_fedora_messaging/tests.py
+++ b/weblate_fedora_messaging/tests.py
@@ -48,4 +48,14 @@ class FedoraTestCase(FixtureTestCase):
             user=user,
             author=User.objects.get(username="jane"),
         )
+
+    @modify_settings(INSTALLED_APPS={"append": "weblate_fedora_messaging"})
+    def test_edit(self):
         self.edit_unit("Hello, world!\n", "Ahoj svete!\n")
+
+    @modify_settings(INSTALLED_APPS={"append": "weblate_fedora_messaging"})
+    def test_plural(self):
+        self.edit_unit(
+            "Orangutan has %d banana.\n\u001e\u001eOrangutan has %d bananas.\n",
+            "Opice má %d banán.\n",
+        )


### PR DESCRIPTION
Send plurals as an array
    
This is consistent with the Weblate 4.3 API and makes it less likely to break because of special chars included in the payload.

Fixes #19