### PR TITLE
Add settings for `fedora_messaging_change` task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,11 @@ Configure Weblate integration:
    INSTALLED_APPS.append("weblate_fedora_messaging")
    # Path to configuration file
    FEDORA_MESSAGING_CONF = "/etc/fedora-messaging/config.toml"
+   # fedora_messaging_task retry settings (optional, the following are the default values)
+   FEDORA_MESSAGING_TASK_RETRY_BACKOFF = 600
+   FEDORA_MESSAGING_TASK_RETRY_BACKOFF_MAX = 3600
+   FEDORA_MESSAGING_TASK_RETRY_JITTER = True
+   FEDORA_MESSAGING_TASK_MAX_RETRIES = 3
    # Route messaging to notify queue
    CELERY_TASK_ROUTES["weblate_fedora_messaging.tasks.*"] = {"queue": "notify"}
 


### PR DESCRIPTION
For some projects, it can be useful to configure the task retries policy (backoff time, max retries, etc.). With this change, we allow to configure them using django settings.

Additionally, if the settings are not set, the defaults will be the old values used previous to this commit.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
